### PR TITLE
cluster destroy complete

### DIFF
--- a/ClusterDestroyer/ClusterDestroyer.py
+++ b/ClusterDestroyer/ClusterDestroyer.py
@@ -43,7 +43,7 @@ def destroyServers(clusterDictionary):
         else:
             print clusterDictionary["clusterName"] + ": Destroyed Nodes"
             for i in range(0, int(len(nodeList))):
-                print "\t" + nodeList[i].name + ": " + delnodes[i]
+                print "\t" + nodeList[i].name + ": " + str(delnodes[i])
 
 
     except Exception as e:

--- a/ClusterDestroyer/ClusterDestroyer.py
+++ b/ClusterDestroyer/ClusterDestroyer.py
@@ -43,7 +43,7 @@ def destroyServers(clusterDictionary):
         else:
             print clusterDictionary["clusterName"] + ": Destroyed Nodes"
             for i in range(0, int(len(nodeList))):
-                print(nodeList[i].name, delnodes[i])
+                print "\t" + nodeList[i].name + ": " + delnodes[i]
 
 
     except Exception as e:

--- a/ClusterDestroyer/ClusterDestroyer.py
+++ b/ClusterDestroyer/ClusterDestroyer.py
@@ -43,7 +43,7 @@ def destroyServers(clusterDictionary):
         else:
             print clusterDictionary["clusterName"] + ": Destroyed Nodes"
             for i in range(0, int(len(nodeList))):
-                print("\t" + nodeList[i].name, delnodes[i])
+                print(nodeList[i].name, delnodes[i])
 
 
     except Exception as e:

--- a/ClusterDestroyer/ClusterDestroyer.py
+++ b/ClusterDestroyer/ClusterDestroyer.py
@@ -29,14 +29,21 @@ def destroyServers(clusterDictionary):
         for node in nodes:
             if clusterDictionary["clusterName"] in node.name:
                 nodeList.append(node)
-                print node
-                print node.extra
+                # print node
+                # print node.extra
 
 
         delnodes = driver.ex_destroy_multiple_nodes(nodeList, ignore_errors=True,
                                                    destroy_boot_disk=False,
                                                    poll_interval=2, timeout=180)
-        print delnodes
+        if (len(nodeList)) != (len(delnodes)):
+            print clusterDictionary["clusterName"] + ": We may have deleted \
+                more nodes than expected!! "
+            print delnodes
+        else:
+            print clusterDictionary["clusterName"] + ": Destroyed Nodes"
+            for i in range(0, int(len(nodeList))):
+                print("\t" + nodeList[i].name, delnodes[i])
 
 
     except Exception as e:

--- a/cape.py
+++ b/cape.py
@@ -44,7 +44,7 @@ def cliParse():
                               required=True)
     parser_query.add_argument("--nodes", dest='nodes', default=1, action="store", help="Number of Nodes to be Queried",
                                required=True)
-    parser_query.add_argument("--config", dest='config', default='./configs/config.env'action="store", help="Config.env file",
+    parser_query.add_argument("--config", dest='config', default='./configs/config.env', action="store", help="Config.env file",
                                required=False)
     # Adding in type as an optinoal arg for now. to be used in the future
     parser_query.add_argument("--type", dest='type', action="store",

--- a/cape.py
+++ b/cape.py
@@ -32,7 +32,7 @@ def cliParse():
 
     parser_create.add_argument("-v", dest='verbose', action='store_true', required=False)
 
-    parser_create.add_argument("--config", dest='config', action="store", help="Config.env file",
+    parser_create.add_argument("--config", dest='config', default='./configs/config.env', action="store", help="Config.env file",
                                required=False)
 
     #parser_create.add_argument("-l", dest='lab', action='store_true', required=False,
@@ -44,7 +44,7 @@ def cliParse():
                               required=True)
     parser_query.add_argument("--nodes", dest='nodes', default=1, action="store", help="Number of Nodes to be Queried",
                                required=True)
-    parser_query.add_argument("--config", dest='config', action="store", help="Config.env file",
+    parser_query.add_argument("--config", dest='config', default='./configs/config.env'action="store", help="Config.env file",
                                required=False)
     # Adding in type as an optinoal arg for now. to be used in the future
     parser_query.add_argument("--type", dest='type', action="store",
@@ -56,7 +56,7 @@ def cliParse():
 
     parser_destroy.add_argument("--name", dest='clustername', action="store",help="Name of Cluster to be Deleted",required=True)
 
-    parser_destroy.add_argument("--config", dest='config', action="store", help="Config.env file",
+    parser_destroy.add_argument("--config", dest='config', default='./configs/config.env', action="store", help="Config.env file",
                                required=False)
     parser_destroy.add_argument("--nodes", dest='nodes', default=1, action="store", help="Number of Nodes to be Created",
                                required=True)
@@ -77,7 +77,7 @@ def cliParse():
         clusterDictionary["accessCount"] = 0
         clusterDictionary["segmentCount"] = 0
         if (args.config):
-            print "External Configuration"
+            print "Loading Configuration"
             load_dotenv(args.config)
 
         if (args.type == "vanilla"):
@@ -127,7 +127,7 @@ def cliParse():
         clusterDictionary["clusterName"] = args.clustername
         clusterDictionary["nodeQty"] = args.nodes
         if (args.config):
-            print "External Configuration"
+            print "Loading Configuration"
             load_dotenv(args.config)
         print clusterDictionary["clusterName"] + ": Querying Nodes in a Cluster"
         QueryCluster.checkServerState(clusterDictionary)
@@ -135,7 +135,7 @@ def cliParse():
         clusterDictionary["clusterName"] = args.clustername
         clusterDictionary["nodeQty"] = args.nodes
         if (args.config):
-            print "External Configuration"
+            print "Loading Configuration"
             load_dotenv(args.config)
         print clusterDictionary["clusterName"] + ": Destroying Cluster"
         ClusterDestroyer.destroyServers(clusterDictionary)
@@ -144,10 +144,7 @@ def cliParse():
 if __name__ == '__main__':
     startTime = datetime.datetime.today()
     print  "Start Time: ", startTime
-    dotenv_path = "./configs/config.env"
-    load_dotenv(dotenv_path)
     os.environ["CAPE_HOME"] = os.getcwd()
-    os.environ["CONFIGS_PATH"] = os.getcwd() + "/configs/"
     cliParse()
     stopTime = datetime.datetime.today()
     print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime

--- a/cape.py
+++ b/cape.py
@@ -79,6 +79,7 @@ def cliParse():
         if (args.config):
             print "Loading Configuration"
             load_dotenv(args.config)
+            os.environ["CONFIGS_PATH"] = args.config
 
         if (args.type == "vanilla"):
             ClusterBuilder.buildServers(clusterDictionary)
@@ -129,6 +130,7 @@ def cliParse():
         if (args.config):
             print "Loading Configuration"
             load_dotenv(args.config)
+            os.environ["CONFIGS_PATH"] = args.config
         print clusterDictionary["clusterName"] + ": Querying Nodes in a Cluster"
         QueryCluster.checkServerState(clusterDictionary)
     elif (args.subparser_name == "destroy"):
@@ -137,6 +139,7 @@ def cliParse():
         if (args.config):
             print "Loading Configuration"
             load_dotenv(args.config)
+            os.environ["CONFIGS_PATH"] = args.config
         print clusterDictionary["clusterName"] + ": Destroying Cluster"
         ClusterDestroyer.destroyServers(clusterDictionary)
 

--- a/cape.py
+++ b/cape.py
@@ -46,6 +46,9 @@ def cliParse():
                                required=True)
     parser_query.add_argument("--config", dest='config', action="store", help="Config.env file",
                                required=False)
+    # Adding in type as an optinoal arg for now. to be used in the future
+    parser_query.add_argument("--type", dest='type', action="store",
+                               help="Type of cluster to be create (gpdb/hdb/vanilla", required=False)
     parser_gpdb.add_argument("--clustername", dest='clustername', action="store", help="Name of Cluster to be Staged",
                              required=True)
 
@@ -57,6 +60,9 @@ def cliParse():
                                required=False)
     parser_destroy.add_argument("--nodes", dest='nodes', default=1, action="store", help="Number of Nodes to be Created",
                                required=True)
+    # Adding in type as an optinoal arg for now. to be used in the future
+    parser_destroy.add_argument("--type", dest='type', action="store",
+                               help="Type of cluster to be create (gpdb/hdb/vanilla", required=False)
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Catch: Should document that cluster names can not be overlapping as all nodes that have that name will be destroyed. 