### PR TITLE
Partial Logging and bug fixes

### DIFF
--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -184,7 +184,7 @@ def prepServer(clusterDictionary,clusterNode, nodeCnt):
         else:
             clusterNode["role"] = "worker"
             clusterDictionary["segmentCount"] += 1
-    logging.debug('Roles set')
+    logging.debug('Role set')
     logging.debug(json.dumps(clusterDictionary))
 
     connected = False

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -334,6 +334,8 @@ def keyShare(clusterDictionary):
                 logging.debug(stdout.readlines())
                 logging.debug(stderr.readlines())
                 for node1 in clusterDictionary["clusterNodes"]:
+                    if '000' in node1["nodeName"]:
+                            break
                     logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
                     logging.debug(stdout.readlines())
@@ -356,6 +358,8 @@ def keyShare(clusterDictionary):
                 logging.debug('Configure SSH settings')
                 ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
                 for node1 in clusterDictionary["clusterNodes"]:
+                    if '000' in node1["nodeName"]:
+                            break
                     logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["ROOT_PW"] + "  ssh root@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
                     logging.debug(stdout.readlines())

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -5,6 +5,7 @@ import warnings
 import traceback
 import paramiko
 import logging
+import json
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 from paramiko import WarningPolicy
@@ -47,7 +48,7 @@ def buildServers(clusterDictionary):
 
     clusterNodes = []
     logging.debug('Will create ' + str(clusterDictionary["nodeQty"]) +
-                  'Nodes with Info below:')
+                  ' Nodes with Info below:')
     logging.debug('SVC_ACCOUNT: ' + str(os.environ["SVC_ACCOUNT"]))
     logging.debug('CONFIGS_PATH: '+ str(os.environ["CONFIGS_PATH"]))
     logging.debug('SVC_ACCOUNT_KEY: ' + str(os.environ["SVC_ACCOUNT_KEY"]))
@@ -286,7 +287,7 @@ def hostsFiles(clusterDictionary):
     logging.debug('Wrote allhosts and workers file')
     threads = []
     for clusterNode in clusterDictionary["clusterNodes"]:
-        logging.debug('Starting uploadThread for: ' clusterNode)
+        logging.debug('Starting uploadThread for: ' + clusterNode)
         uploadThread = threading.Thread(target=hostFileUpload, args=(clusterNode,))
         threads.append(uploadThread)
         uploadThread.start()

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -13,9 +13,9 @@ from paramiko import AutoAddPolicy
 
 
 logging.basicConfig(filename='cape.log', level=logging.DEBUG,
-                    format='[%(asctime)s] %(module)s \
-                    {%(pathname)s:%(funcName)s:%(lineno)d} %(levelname)s -\
-                     %(message)s')
+                    format='[%(asctime)s] %(pathname)s \
+                    {%(module)s:%(funcName)s:%(lineno)d} %(levelname)s \
+                    %(threadName)s - %(message)s')
 
 
 def buildServers(clusterDictionary):
@@ -128,7 +128,7 @@ def buildServers(clusterDictionary):
     print clusterDictionary["clusterName"] + ": Cluster Configuration Complete"
     logging.info(clusterDictionary["clusterName"] + ": Cluster Configuration Complete")
     clusterDictionary["clusterNodes"] = clusterNodes
-    logging.debug('ClusterNodes: ' + + json.dumps(clusterDictionary["clusterNodes"]))
+    logging.debug('ClusterNodes: ' + json.dumps(clusterDictionary["clusterNodes"]))
     getNodeFQDN(clusterDictionary)
     hostsFiles(clusterDictionary)
     keyShare(clusterDictionary)
@@ -242,7 +242,7 @@ def prepServer(clusterDictionary,clusterNode, nodeCnt):
             print clusterNode["nodeName"]+": Rebooting"
             logging.debug(clusterNode["nodeName"] + ': Rebooting')
             (stdin, stdout, stderr) = ssh.exec_command("sudo reboot")
-            logigng.debug(stdout.readlines())
+            logging.debug(stdout.readlines())
             logging.debug(stderr.readlines())
             connected = True
         except Exception as e:

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -130,6 +130,7 @@ def buildServers(clusterDictionary):
     clusterDictionary["clusterNodes"] = clusterNodes
     logging.debug('ClusterNodes: ' + json.dumps(clusterDictionary["clusterNodes"]))
     getNodeFQDN(clusterDictionary)
+    logging.debug(json.dumps(clusterDictionary))
     hostsFiles(clusterDictionary)
     keyShare(clusterDictionary)
     logging.debug('buildServers Completed')
@@ -185,7 +186,6 @@ def prepServer(clusterDictionary,clusterNode, nodeCnt):
             clusterNode["role"] = "worker"
             clusterDictionary["segmentCount"] += 1
     logging.debug('Role set')
-    logging.debug(json.dumps(clusterDictionary))
 
     connected = False
     attemptCount = 0
@@ -473,5 +473,4 @@ def getNodeFQDN(clusterDictionary):
                 exit()
         finally:
             ssh.close()
-            logging.debug(+ json.dumps(clusterDictionary))
             logging.debug('getNodeFQDN Completed')

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -201,7 +201,7 @@ def prepServer(clusterDictionary,clusterNode, nodeCnt):
                           str(os.environ["CONFIGS_PATH"]) +
                           str(os.environ["SSH_KEY"]))
             ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
-                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
+                        key_filename=(str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"])), timeout=120)
             sftp = ssh.open_sftp()
             sftp.put('./templates/sysctl.conf.cape', '/tmp/sysctl.conf.cape', confirm=True)
             logging.debug('Put: ./templates/sysctl.conf.cape')
@@ -406,7 +406,7 @@ def hostFileUpload(clusterNode):
                           str(os.environ["CONFIGS_PATH"]) +
                           str(os.environ["SSH_KEY"]))
             ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
-                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
+                        key_filename=(str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"])), timeout=120)
 
             sftp = ssh.open_sftp()
             sftp.put("hosts", "/tmp/hosts", confirm=True)

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -455,7 +455,7 @@ def getNodeFQDN(clusterDictionary):
                 (stdin, stdout, stderr) = ssh.exec_command("hostname -f ")
                 fqdn = stdout.read()
                 logging.debug(stdout.readlines())
-                logigng.debug(stderr.readlines())
+                logging.debug(stderr.readlines())
                 node["FQDN"] = fqdn.strip()
 
             logging.debug('FQDN set')

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -196,8 +196,8 @@ def prepServer(clusterDictionary,clusterNode, nodeCnt):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
             logging.debug('Connecting to Node: ' + clusterNode["nodeName"])
-            logging.debug('SSH IP: ' + clusterNode["externalIP"] + 'User: ' +
-                          os.environ["SSH_USERNAME"] + 'Key: ' +
+            logging.debug('SSH IP: ' + clusterNode["externalIP"] + ' User: ' +
+                          os.environ["SSH_USERNAME"] + ' Key: ' +
                           str(os.environ["CONFIGS_PATH"]) +
                           str(os.environ["SSH_KEY"]))
             ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
@@ -323,49 +323,49 @@ def keyShare(clusterDictionary):
                 ssh.set_missing_host_key_policy(AutoAddPolicy())
                 logging.debug('Connecting to Node: ' + str(node["nodeName"]))
                 logging.debug('SSH IP: ' + node["externalIP"] +
-                              'User: gpadmin')
+                              ' User: gpadmin')
                 ssh.connect(node["externalIP"], 22, "gpadmin", password=str(os.environ["GPADMIN_PW"]), timeout=120)
                 logging.debug('Generating id_rsa')
                 (stdin, stdout, stderr) = ssh.exec_command("echo -e  'y\n'|ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''")
-                logging.debug(stderr.readlines())
                 logging.debug(stdout.readlines())
+                logging.debug(stderr.readlines())
                 logging.debug('Configure SSH settings')
                 (stdin, stdout, stderr) = ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
-                logging.debug(stderr.readlines())
                 logging.debug(stdout.readlines())
+                logging.debug(stderr.readlines())
                 for node1 in clusterDictionary["clusterNodes"]:
                     logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
-                    logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
+                    logging.debug(stderr.readlines())
                     logging.debug("exchange key ssh-copy-id from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh-copy-id  gpadmin@" + node1["nodeName"])
-                    logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
+                    logging.debug(stderr.readlines())
 
                 ssh.close()
                 logging.debug('Connecting to Node: ' + str(node["nodeName"]))
                 logging.debug('SSH IP: ' + node["externalIP"] +
-                              'User: root')
+                              ' User: root')
                 ssh.connect(node["externalIP"], 22, "root", password=str(os.environ["ROOT_PW"]),
                             timeout=120)
                 logging.debug('Generating id_rsa')
                 (stdin, stdout, stderr) = ssh.exec_command("echo -e  'y\n'|ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''")
-                logging.debug(stderr.readlines())
                 logging.debug(stdout.readlines())
+                logging.debug(stderr.readlines())
                 logging.debug('Configure SSH settings')
                 ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
                 for node1 in clusterDictionary["clusterNodes"]:
                     logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["ROOT_PW"] + "  ssh root@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
-                    logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
+                    logging.debug(stderr.readlines())
                     logging.debug("exchange key ssh-copy-id from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command(
                         "sshpass -p " + os.environ["ROOT_PW"] + "  ssh-copy-id  root@" + node1[
                             "nodeName"])
-                    logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
+                    logging.debug(stderr.readlines())
 
                 connected = True
             except Exception as e:
@@ -401,8 +401,8 @@ def hostFileUpload(clusterNode):
             ssh.set_missing_host_key_policy(WarningPolicy())
             logging.debug('Current Dir: ' + os.getcwd())
             logging.debug('Connecting to Node: ' + clusterNode["nodeName"])
-            logging.debug('SSH IP: ' + clusterNode["externalIP"] + 'User: ' +
-                          os.environ["SSH_USERNAME"] + 'Key: ' +
+            logging.debug('SSH IP: ' + clusterNode["externalIP"] + ' User: ' +
+                          os.environ["SSH_USERNAME"] + ' Key: ' +
                           str(os.environ["CONFIGS_PATH"]) +
                           str(os.environ["SSH_KEY"]))
             ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
@@ -417,8 +417,8 @@ def hostFileUpload(clusterNode):
             logging.debug('Put Workers File')
 
             (stdin, stdout, stderr) = ssh.exec_command("sudo sh -c 'cat /tmp/hosts >> /etc/hosts'")
-            logging.debug(stderr.readlines())
             logging.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
             connected = True
         except Exception as e:
             # print e
@@ -457,8 +457,7 @@ def getNodeFQDN(clusterDictionary):
                 logging.debug(stdout.readlines())
                 logging.debug(stderr.readlines())
                 node["FQDN"] = fqdn.strip()
-
-            logging.debug('FQDN set')
+                logging.debug('FQDN set: ' + str(node["FQDN"]))
             connected = True
         except Exception as e:
             # print e

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -4,21 +4,34 @@ import time
 import warnings
 import traceback
 import paramiko
+import logging
 from libcloud.compute.providers import get_driver
 from libcloud.compute.types import Provider
 from paramiko import WarningPolicy
 from paramiko import AutoAddPolicy
 
 
+logging.basicConfig(filename='cape.log', level=logging.DEBUG,
+                    format='[%(asctime)s] %(module)s \
+                    {%(pathname)s:%(funcName)s:%(lineno)d} %(levelname)s -\
+                     %(message)s')
+
+
 def buildServers(clusterDictionary):
+    logging.debug('buildServers Started')
     warnings.simplefilter("ignore")
+    logging.debug('SimpleFilter for Warnings: ignore')
     print clusterDictionary["clusterName"] + ": Cluster Creation Started"
+    logging.info(clusterDictionary["clusterName"] +
+                 ": Cluster Creation Started")
 
     # ADD ACTUAL CHECKING FOR EXISTING CLUSTER....THIS WAS JUST FOR TEST
 
     try:
         if not os.path.exists(clusterDictionary["clusterName"]):
             os.makedirs("./clusterConfigs/" + clusterDictionary["clusterName"])
+            logging.debug("Created: ./clusterConfigs" +
+                          clusterDictionary["clusterName"])
 
     except OSError:
         if "test" in clusterDictionary["clusterName"]:
@@ -28,9 +41,20 @@ def buildServers(clusterDictionary):
             os.makedirs("./clusterConfigs/" + clusterDictionary["clusterName"])
         else:
             print "Cluster Name already exists."
+            logging.error("Cluster Name already exists. Exiting!")
     clusterPath = "./clusterConfigs/" + clusterDictionary["clusterName"]
+    logging.debug("ClusterPath: " + str(clusterPath))
 
     clusterNodes = []
+    logging.debug('Will create ' + str(clusterDictionary["nodeQty"]) +
+                  'Nodes with Info below:')
+    logging.debug('SVC_ACCOUNT: ' + str(os.environ["SVC_ACCOUNT"]))
+    logging.debug('CONFIGS_PATH: '+ str(os.environ["CONFIGS_PATH"]))
+    logging.debug('SVC_ACCOUNT_KEY: ' + str(os.environ["SVC_ACCOUNT_KEY"]))
+    logging.debug('PROJECT: ' + str(os.environ["PROJECT"]))
+    logging.debug('DATACENTER: ' + str(os.environ["ZONE"]))
+    logging.debug('DISK_TYPE: ' + str(os.environ["DISK_TYPE"])
+    logging.debug('SERVER_TYPE: ' + str(os.environ["SERVER_TYPE"]))
 
     ComputeEngine = get_driver(Provider.GCE)
     driver = ComputeEngine(os.environ["SVC_ACCOUNT"], str(os.environ["CONFIGS_PATH"]) + str(os.environ["SVC_ACCOUNT_KEY"]), project=str(os.environ["PROJECT"]), datacenter=str(os.environ["ZONE"]))
@@ -64,7 +88,9 @@ def buildServers(clusterDictionary):
                                             ex_automatic_restart=None)
 
     print clusterDictionary["clusterName"] + ": Cluster Nodes Created in Google Cloud"
+    logging.info(clusterDictionary["clusterName"] + ": Cluster Nodes Created in Google Cloud")
     print clusterDictionary["clusterName"] + ": Cluster Configuration Started"
+    logging.info(clusterDictionary["clusterName"] + ": Cluster Configuration Started")
 
     threads = []
     buildFSTAB(clusterDictionary, int(os.environ["DISK_QTY"]))
@@ -90,6 +116,7 @@ def buildServers(clusterDictionary):
         clusterNode["internalIP"] = str(node).split(",")[4].split("'")[1]
         print "     " + nodeName + ": External IP: " + clusterNode["externalIP"]
         print "     " + nodeName + ": Internal IP: " + clusterNode["internalIP"]
+        logging.debug('Created Node: ' + str(clusterNode))
 
         prepThread = threading.Thread(target=prepServer, args=(clusterDictionary,clusterNode, nodeCnt))
         clusterNodes.append(clusterNode)
@@ -98,32 +125,44 @@ def buildServers(clusterDictionary):
     for x in threads:
         x.join()
     print clusterDictionary["clusterName"] + ": Cluster Configuration Complete"
+    logging.info(clusterDictionary["clusterName"] + ": Cluster Configuration Complete")
     clusterDictionary["clusterNodes"] = clusterNodes
+    logging.debug('ClusterNodes: ' + + json.dumps(clusterDictionary["clusterNodes"]))
     getNodeFQDN(clusterDictionary)
     hostsFiles(clusterDictionary)
     keyShare(clusterDictionary)
+    logging.debug('buildServers Completed')
 
 def buildFSTAB(clusterDictionary,diskCNT):
+    logging.debug('buildFSTAB Started')
     clusterPath = "./clusterConfigs/" + clusterDictionary["clusterName"]
     currentPath = os.getcwd()
+    logging.debug('Current Dir: ' + currentPath))
     os.chdir(clusterPath)
+    logging.debug('Changed Dir to: ' + clusterPath)
     with open("fstab.cape", "w") as fstabFile:
         fstabFile.write("######  CAPE ENTRIES #######\n")
         fstabFile.write("/swapfile    swap     swap    defaults     0 0\n")
         for disk in range(1,diskCNT+1):
             fstabFile.write("LABEL=data"+str(disk)+ "   /data/disk"+str(disk) + "   xfs rw,noatime,inode64,allocsize=16m 0 0\n")
+    logging.info('Wrote fstab file')
     os.chdir(currentPath)
+    logging.debug('Changed Dir to: ' + currentPath)
+    logging.debug('buildFSTAB Completed')
 
 
 
 
 def prepServer(clusterDictionary,clusterNode, nodeCnt):
+    logging.debug('prepServer Started')
     warnings.simplefilter("ignore")
+    logging.debug('SimpleFilter for Warnings: ignore')
     paramiko.util.log_to_file("/tmp/paramiko.log")
     nodeName = clusterNode["nodeName"]
 
     # Set Server Role
     if os.environ["STANDBY"] == "yes" and os.environ["ACCESS"] == "yes":
+        logging.debug('STANDBY and ACCESS are yes')
         if (nodeCnt) == 0:
             clusterNode["role"] = "access"
             clusterDictionary["accessCount"] += 1
@@ -137,75 +176,100 @@ def prepServer(clusterDictionary,clusterNode, nodeCnt):
             clusterNode["role"] = "worker"
             clusterDictionary["segmentCount"] += 1
     elif os.environ["STANDBY"] == "no" and os.environ["ACCESS"] == "no":
+        logging.debug('STANDBY and ACCESS are no')
         if (nodeCnt) == 0:
             clusterNode["role"] = "master1"
             clusterDictionary["masterCount"] += 1
         else:
             clusterNode["role"] = "worker"
             clusterDictionary["segmentCount"] += 1
+    logging.debug('Roles set')
+    logging.debug(json.dumps(clusterDictionary))
 
     connected = False
     attemptCount = 0
     while not connected:
         try:
+            logging.debug('Current Dir: ' + str(os.getcwd()))
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
+            logging.debug('Connecting to Node: ' + clusterNode["nodeName"])
+            logging.debug('SSH IP: ' + clusterNode["externalIP"] + 'User: ' +
+                          os.environ["SSH_USERNAME"] + 'Key: ' +
+                          str(os.environ["CONFIGS_PATH"]) +
+                          str(os.environ["SSH_KEY"]))
             ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
                         key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
             sftp = ssh.open_sftp()
             sftp.put('./templates/sysctl.conf.cape', '/tmp/sysctl.conf.cape', confirm=True)
+            logging.debug('Put: ./templates/sysctl.conf.cape')
             sftp.put('./clusterConfigs/' + clusterDictionary["clusterName"]+ '/fstab.cape', '/tmp/fstab.cape', confirm=True)
+            logging.debug('Put: ./clusterConfigs/' +
+                          clusterDictionary["clusterName"] + '/fstab.cape')
             sftp.put('./templates/limits.conf.cape', '/tmp/limits.conf.cape', confirm=True)
+            logging.debug('Put: ./templates/limits.conf.cape')
             sftp.put('./scripts/prepareHost.sh', '/tmp/prepareHost.sh', confirm=True)
+            logging.debug('Put: ./scripts/prepareHost.sh')
 
             time.sleep(10)
 
-
+            logging.debug('Createing user root')
             (stdin, stdout, stderr) = ssh.exec_command("sudo echo " + os.environ["ROOT_PW"] + " | sudo passwd --stdin root")
-            stdout.readlines()
-            stderr.readlines()
+            logging.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
+            logging.debug('Making prepareHost executable')
             ssh.exec_command("sudo chmod +x /tmp/prepareHost.sh")
             (stdin, stdout, stderr) = ssh.exec_command("/tmp/prepareHost.sh " + os.environ["DISK_QTY"] + " &> /tmp/prepareHost.log")
-            stdout.readlines()
-            stderr.readlines()
+            logging.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
+            logging.debug("Making /data and mounting drives")
             (stdin, stdout, stderr) = ssh.exec_command("sudo mkdir /data;sudo mount -a")
-            stdout.readlines()
-            stderr.readlines()
+            logging.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
             homeDir = os.environ["BASE_HOME"] + "/home"
+            logging.debug('Adding user gpadmin with homdir path: ' + homeDir)
             (stdin, stdout, stderr) = ssh.exec_command("sudo mkdir -p " + homeDir + ";sudo useradd -b " + homeDir + " -s " + "/bin/bash -m gpadmin")
-            stdout.readlines()
-            stderr.readlines()
-
+            logging.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
+            logging.debug('Setting gpadmin password')
             (stdin, stdout, stderr) = ssh.exec_command("sudo echo " + os.environ["GPADMIN_PW"] + " | sudo passwd --stdin gpadmin")
-            stdout.readlines()
-            stderr.readlines()
+            logging.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
 
             # could change to node.reboot
             print clusterNode["nodeName"]+": Rebooting"
+            logging.debug(clusterNode["nodeName"] + ': Rebooting')
             (stdin, stdout, stderr) = ssh.exec_command("sudo reboot")
-            stdout.readlines()
-            stderr.readlines()
+            logigng.debug(stdout.readlines())
+            logging.debug(stderr.readlines())
             connected = True
         except Exception as e:
             print "     " + nodeName + ": Attempting SSH Connection"
             time.sleep(3)
 
             if attemptCount > 40:
+                logging.debug('Exception: ' + str(e))
+                logging.debug(traceback.print_exc())
+                logging.debug('Cluster Creation FAILED')
                 print "CLUSTER CREATION FAILED:   Cleanup and Retry"
                 exit()
         finally:
             ssh.close()
+            logging.debug('prepServer Completed')
     return
 
 
 def hostsFiles(clusterDictionary):
+    logging.debug('hostFiles Started')
     clusterPath = "./clusterConfigs/" + clusterDictionary["clusterName"]
     os.chdir(clusterPath)
+    logging.debug('Changed Dir to: ' + os.getcwd())
     with open("hosts", "w") as hostsFile:
         hostsFile.write("######  CAPE ENTRIES #######\n")
         for node in clusterDictionary["clusterNodes"]:
             hostsFile.write(node["internalIP"] + "  " + node["nodeName"] + "  " + node["FQDN"] + "\n")
+    logging.debug('Wrote hosts file')
 
     with open("workers", "w") as workersFile:
         with open("allhosts", "w") as allhostsFile:
@@ -219,13 +283,16 @@ def hostsFiles(clusterDictionary):
                 else:
                     workersFile.write(node["nodeName"] + "\n")
                     allhostsFile.write(node["nodeName"] + "\n")
+    logging.debug('Wrote allhosts and workers file')
     threads = []
     for clusterNode in clusterDictionary["clusterNodes"]:
+        logging.debug('Starting uploadThread for: ' clusterNode)
         uploadThread = threading.Thread(target=hostFileUpload, args=(clusterNode,))
         threads.append(uploadThread)
         uploadThread.start()
     for x in threads:
         x.join()
+    logging.debug('hostFiles Completed')
 
 
 def verifyCluster(clusterDictionary):
@@ -237,14 +304,14 @@ def verifyCluster(clusterDictionary):
 
 def keyShare(clusterDictionary):
     # NEED TO THREAD THE KEY SHARE TAKES WAY TOO LONG
-
+    logging.debug('keyShare Started')
     warnings.simplefilter("ignore")
+    logging.debug('SimpleFilter for Warnings: ignore')
     paramiko.util.log_to_file("/tmp/paramiko.log")
 
-    # client.connect(clusterNode["externalIP"], 22, SSH_USERNAME, None, pkey=None, key_filename=SSH_KEY_PATH, timeout=120)
 
     for node in clusterDictionary["clusterNodes"]:
-        print("Working on Node: " + str(node["nodeName"]))
+        logging.debug("Working on Node: " + str(node["nodeName"]))
 
         connected = False
         attemptCount = 0
@@ -253,38 +320,51 @@ def keyShare(clusterDictionary):
                 attemptCount += 1
                 ssh = paramiko.SSHClient()
                 ssh.set_missing_host_key_policy(AutoAddPolicy())
-
+                logging.debug('Connecting to Node: ' + str(clusterNode["nodeName"]))
+                logging.debug('SSH IP: ' + clusterNode["externalIP"] +
+                              'User: gpadmin')
                 ssh.connect(node["externalIP"], 22, "gpadmin", password=str(os.environ["GPADMIN_PW"]), timeout=120)
+                logging.debug('Generating id_rsa')
                 (stdin, stdout, stderr) = ssh.exec_command("echo -e  'y\n'|ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''")
-                #(stdin, stdout, stderr) = ssh.exec_command("sudo rm -f /etc/yum.repos.d/CentOS-SCL*;sudo yum clean all")
-                #stderr.readlines()
-                #stdout.readlines()
-                # (stdin, stdout, stderr) = ssh.exec_command("sudo rm -f /etc/yum.repos.d/CentOS-SCL*;sudo yum clean all;sudo yum install -y epel-release;sudo yum install -y sshpass git")
-                # stderr.readlines()
-                # stdout.readlines()
-                ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
+                logging.debug(stderr.readlines())
+                logging.debug(stdout.readlines())
+                logging.debug('Configure SSH settings')
+                (stdin, stdout, stderr) = ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
+                logging.debug(stderr.readlines())
+                logging.debug(stdout.readlines())
                 for node1 in clusterDictionary["clusterNodes"]:
-                    # print("\t exchanging gpadmin key with " + str(node1["nodeName"]))
+                    logging.debug("exchange key ssh from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
+                    logging.debug(stderr.readlines())
+                    logging.debug(stdout.readlines())
+                    logging.debug("exchange key ssh-copy-id from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh-copy-id  gpadmin@" + node1["nodeName"])
-                    stderr.readlines()
-                    stdout.readlines()
+                    logging.debug(stderr.readlines())
+                    logging.debug(stdout.readlines())
 
                 ssh.close()
+                logging.debug('Connecting to Node: ' + str(clusterNode["nodeName"]))
+                logging.debug('SSH IP: ' + clusterNode["externalIP"] +
+                              'User: root')
                 ssh.connect(node["externalIP"], 22, "root", password=str(os.environ["ROOT_PW"]),
                             timeout=120)
+                logging.debug('Generating id_rsa')
                 (stdin, stdout, stderr) = ssh.exec_command("echo -e  'y\n'|ssh-keygen -f ~/.ssh/id_rsa -t rsa -N ''")
-                stderr.readlines()
-                stdout.readlines()
+                logging.debug(stderr.readlines())
+                logging.debug(stdout.readlines())
+                logging.debug('Configure SSH settings')
                 ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
                 for node1 in clusterDictionary["clusterNodes"]:
-                    # print("\t exchanging root key with " + str(node1["nodeName"]))
+                    logging.debug("exchange key ssh from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["ROOT_PW"] + "  ssh root@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
+                    logging.debug(stderr.readlines())
+                    logging.debug(stdout.readlines())
+                    logging.debug("exchange key ssh-copy-id from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command(
                         "sshpass -p " + os.environ["ROOT_PW"] + "  ssh-copy-id  root@" + node1[
                             "nodeName"])
-                    stderr.readlines()
-                    stdout.readlines()
+                    logging.debug(stderr.readlines())
+                    logging.debug(stdout.readlines())
 
                 connected = True
             except Exception as e:
@@ -294,14 +374,20 @@ def keyShare(clusterDictionary):
                 time.sleep(3)
                 print ("attempt Count: " + attemptCount + "/40")
                 if attemptCount > 40:
+                    logging.debug('Exception: ' + str(e))
+                    logging.debug(traceback.print_exc())
+                    logging.debug('Failed')
                     print "Failing Process"
                     exit()
             finally:
                 ssh.close()
+                logging.debug('keyShare Completed')
 
 
 def hostFileUpload(clusterNode):
+    logging.debug('hostFileUpload Started')
     warnings.simplefilter("ignore")
+    logging.debug('SimpleFilter for Warnings: ignore')
     paramiko.util.log_to_file("/tmp/paramiko.log")
 
     connected = False
@@ -312,29 +398,46 @@ def hostFileUpload(clusterNode):
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
+            logging.debug('Current Dir: ' + os.getcwd())
+            logging.debug('Connecting to Node: ' + clusterNode["nodeName"])
+            logging.debug('SSH IP: ' + clusterNode["externalIP"] + 'User: ' +
+                          os.environ["SSH_USERNAME"] + 'Key: ' +
+                          str(os.environ["CONFIGS_PATH"]) +
+                          str(os.environ["SSH_KEY"]))
             ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
                         key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
 
             sftp = ssh.open_sftp()
-            sftp.put("hosts", "/tmp/hosts")
-            sftp.put("allhosts", "/tmp/allhosts")
-            sftp.put("workers", "/tmp/workers")
+            sftp.put("hosts", "/tmp/hosts", confirm=True)
+            logging.debug('Put hosts file')
+            sftp.put("allhosts", "/tmp/allhosts", confirm=True)
+            logging.debug('Put allhosts file')
+            sftp.put("workers", "/tmp/workers", confirm=True)
+            logging.debug('Put Workers File')
 
             (stdin, stdout, stderr) = ssh.exec_command("sudo sh -c 'cat /tmp/hosts >> /etc/hosts'")
+            logging.debug(stderr.readlines())
+            logging.debug(stdout.readlines())
             connected = True
         except Exception as e:
             # print e
             print "     " + clusterNode["nodeName"] + ": Attempting SSH Connection"
             time.sleep(3)
             if attemptCount > 40:
+                logging.debug('Exception: ' + str(e))
+                logging.debug(traceback.print_exc())
+                logging.debug('Failed')
                 print "Failing Process"
                 exit()
         finally:
             ssh.close()
+            logging.debug('hostFileUpload Completed')
 
 
 def getNodeFQDN(clusterDictionary):
+    logging.debug('getNodeFQDN Started')
     warnings.simplefilter("ignore")
+    logging.debug('SimpleFilter for Warnings: ignore')
     paramiko.util.log_to_file("/tmp/paramiko.log")
 
     connected = False
@@ -346,13 +449,15 @@ def getNodeFQDN(clusterDictionary):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
             for node in clusterDictionary["clusterNodes"]:
+                logging.debug('Connecting to ' + node["nodeName"])
                 ssh.connect(node["externalIP"], 22, "gpadmin", password=str(os.environ["GPADMIN_PW"]), timeout=120)
                 (stdin, stdout, stderr) = ssh.exec_command("hostname -f ")
                 fqdn = stdout.read()
-                stdout.readlines()
-                stderr.readlines()
+                logging.debug(stdout.readlines())
+                logigng.debug(stderr.readlines())
                 node["FQDN"] = fqdn.strip()
 
+            logging.debug('FQDN set')
             connected = True
         except Exception as e:
             # print e
@@ -360,7 +465,12 @@ def getNodeFQDN(clusterDictionary):
             print "     " + node["nodeName"] + ": Attempting SSH Connection"
             time.sleep(3)
             if attemptCount > 40:
+                logging.debug('Exception: ' + str(e))
+                logging.debug(traceback.print_exc())
+                logging.debug('Failed')
                 print "Failing Process"
                 exit()
         finally:
             ssh.close()
+            logging.debug(+ json.dumps(clusterDictionary))
+            logging.debug('getNodeFQDN Completed')

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -334,14 +334,23 @@ def keyShare(clusterDictionary):
                 logging.debug(stdout.readlines())
                 logging.debug(stderr.readlines())
                 for node1 in clusterDictionary["clusterNodes"]:
-                    if '000' in node1["nodeName"]:
-                            break
-                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
-                    (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
+                    # Explicitly writing exit so ssh session does not hang
+                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]) + " using internal IP")
+                    (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no")
+                    stdin.write('exit \n')
+                    stdin.flush()
+                    logging.debug(stdout.readlines())
+                    logging.debug(stderr.readlines())
+                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]) + " using FQDN")
+                    (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["FQDN"]+ " -o StrictHostKeyChecking=no")
+                    stdin.write('exit \n')
+                    stdin.flush()
                     logging.debug(stdout.readlines())
                     logging.debug(stderr.readlines())
                     logging.debug("exchange key ssh-copy-id from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh-copy-id  gpadmin@" + node1["nodeName"])
+                    stdin.write('exit \n')
+                    stdin.flush()
                     logging.debug(stdout.readlines())
                     logging.debug(stderr.readlines())
 
@@ -358,16 +367,25 @@ def keyShare(clusterDictionary):
                 logging.debug('Configure SSH settings')
                 ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
                 for node1 in clusterDictionary["clusterNodes"]:
-                    if '000' in node1["nodeName"]:
-                            break
-                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
+                    # explicitly writing exit to stdin so ssh session does not hang
+                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]) + " using internal IP")
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["ROOT_PW"] + "  ssh root@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
+                    stdin.write('exit \n')
+                    stdin.flush()
+                    logging.debug(stdout.readlines())
+                    logging.debug(stderr.readlines())
+                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]) + " using FQDN")
+                    (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["ROOT_PW"] + "  ssh root@" + node1["FQDN"]+ " -o StrictHostKeyChecking=no" )
+                    stdin.write('exit \n')
+                    stdin.flush()
                     logging.debug(stdout.readlines())
                     logging.debug(stderr.readlines())
                     logging.debug("exchange key ssh-copy-id from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command(
                         "sshpass -p " + os.environ["ROOT_PW"] + "  ssh-copy-id  root@" + node1[
                             "nodeName"])
+                    stdin.write('exit \n')
+                    stdin.flush()
                     logging.debug(stdout.readlines())
                     logging.debug(stderr.readlines())
 

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -12,12 +12,6 @@ from paramiko import WarningPolicy
 from paramiko import AutoAddPolicy
 
 
-logging.basicConfig(filename='cape.log', level=logging.DEBUG,
-                    format='[%(asctime)s] %(pathname)s \
-                    {%(module)s:%(funcName)s:%(lineno)d} %(levelname)s \
-                    %(threadName)s - %(message)s')
-
-
 def buildServers(clusterDictionary):
     logging.debug('buildServers Started')
     warnings.simplefilter("ignore")

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -321,8 +321,8 @@ def keyShare(clusterDictionary):
                 attemptCount += 1
                 ssh = paramiko.SSHClient()
                 ssh.set_missing_host_key_policy(AutoAddPolicy())
-                logging.debug('Connecting to Node: ' + str(clusterNode["nodeName"]))
-                logging.debug('SSH IP: ' + clusterNode["externalIP"] +
+                logging.debug('Connecting to Node: ' + str(node["nodeName"]))
+                logging.debug('SSH IP: ' + node["externalIP"] +
                               'User: gpadmin')
                 ssh.connect(node["externalIP"], 22, "gpadmin", password=str(os.environ["GPADMIN_PW"]), timeout=120)
                 logging.debug('Generating id_rsa')
@@ -334,18 +334,18 @@ def keyShare(clusterDictionary):
                 logging.debug(stderr.readlines())
                 logging.debug(stdout.readlines())
                 for node1 in clusterDictionary["clusterNodes"]:
-                    logging.debug("exchange key ssh from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
+                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh gpadmin@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
                     logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
-                    logging.debug("exchange key ssh-copy-id from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
+                    logging.debug("exchange key ssh-copy-id from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["GPADMIN_PW"] + "  ssh-copy-id  gpadmin@" + node1["nodeName"])
                     logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
 
                 ssh.close()
-                logging.debug('Connecting to Node: ' + str(clusterNode["nodeName"]))
-                logging.debug('SSH IP: ' + clusterNode["externalIP"] +
+                logging.debug('Connecting to Node: ' + str(node["nodeName"]))
+                logging.debug('SSH IP: ' + node["externalIP"] +
                               'User: root')
                 ssh.connect(node["externalIP"], 22, "root", password=str(os.environ["ROOT_PW"]),
                             timeout=120)
@@ -356,11 +356,11 @@ def keyShare(clusterDictionary):
                 logging.debug('Configure SSH settings')
                 ssh.exec_command("echo 'Host *\nStrictHostKeyChecking no' >> ~/.ssh/config;chmod 400 ~/.ssh/config")
                 for node1 in clusterDictionary["clusterNodes"]:
-                    logging.debug("exchange key ssh from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
+                    logging.debug("exchange key ssh from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command("sshpass -p " + os.environ["ROOT_PW"] + "  ssh root@" + node1["internalIP"]+ " -o StrictHostKeyChecking=no" )
                     logging.debug(stderr.readlines())
                     logging.debug(stdout.readlines())
-                    logging.debug("exchange key ssh-copy-id from " + str(clusterNode["nodeName"]) + " to " + str(node1["nodeName"]))
+                    logging.debug("exchange key ssh-copy-id from " + str(node["nodeName"]) + " to " + str(node1["nodeName"]))
                     (stdin, stdout, stderr) = ssh.exec_command(
                         "sshpass -p " + os.environ["ROOT_PW"] + "  ssh-copy-id  root@" + node1[
                             "nodeName"])

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -137,7 +137,7 @@ def buildFSTAB(clusterDictionary,diskCNT):
     logging.debug('buildFSTAB Started')
     clusterPath = "./clusterConfigs/" + clusterDictionary["clusterName"]
     currentPath = os.getcwd()
-    logging.debug('Current Dir: ' + currentPath))
+    logging.debug('Current Dir: ' + currentPath)
     os.chdir(clusterPath)
     logging.debug('Changed Dir to: ' + clusterPath)
     with open("fstab.cape", "w") as fstabFile:

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -373,7 +373,7 @@ def keyShare(clusterDictionary):
                 print traceback.print_exc()
                 print node["nodeName"] + ": Attempting SSH Connection"
                 time.sleep(3)
-                print ("attempt Count: " + attemptCount + "/40")
+                print ("attempt Count: " + str(attemptCount) + "/40")
                 if attemptCount > 40:
                     logging.debug('Exception: ' + str(e))
                     logging.debug(traceback.print_exc())

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -287,7 +287,7 @@ def hostsFiles(clusterDictionary):
     logging.debug('Wrote allhosts and workers file')
     threads = []
     for clusterNode in clusterDictionary["clusterNodes"]:
-        logging.debug('Starting uploadThread for: ' + clusterNode)
+        logging.debug('Starting uploadThread for: ' + str(clusterNode["nodeName"]))
         uploadThread = threading.Thread(target=hostFileUpload, args=(clusterNode,))
         threads.append(uploadThread)
         uploadThread.start()

--- a/ClusterBuilder/ClusterBuilder.py
+++ b/ClusterBuilder/ClusterBuilder.py
@@ -53,7 +53,7 @@ def buildServers(clusterDictionary):
     logging.debug('SVC_ACCOUNT_KEY: ' + str(os.environ["SVC_ACCOUNT_KEY"]))
     logging.debug('PROJECT: ' + str(os.environ["PROJECT"]))
     logging.debug('DATACENTER: ' + str(os.environ["ZONE"]))
-    logging.debug('DISK_TYPE: ' + str(os.environ["DISK_TYPE"])
+    logging.debug('DISK_TYPE: ' + str(os.environ["DISK_TYPE"]))
     logging.debug('SERVER_TYPE: ' + str(os.environ["SERVER_TYPE"]))
 
     ComputeEngine = get_driver(Provider.GCE)

--- a/ClusterBuilder/InstallGPDB.py
+++ b/ClusterBuilder/InstallGPDB.py
@@ -111,7 +111,7 @@ def installComponents(masterNode, downloads):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
 
-            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
             (stdin, stdout, stderr) = ssh.exec_command("createlang plpythonu -d template1")
             stdout.readlines()
             stderr.readlines()
@@ -159,7 +159,7 @@ def verifyInstall(masterNode, clusterDictionary):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
 
-            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
             (stdin, stdout, stderr) = ssh.exec_command(
                 "psql -c \"SELECT version() ;\"")
             return_code = stdout.channel.recv_exit_status()
@@ -227,7 +227,7 @@ def installDSPackages(clusterNode):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
 
-            ssh.connect(clusterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(clusterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
 
             # FIX FOR GENSIM
             (stdin, stdout, stderr) = ssh.exec_command("echo -e 'import sys\nsys.setdefaultencoding(\"utf-8\")' >> /usr/local/greenplum-db-4.3.9.1/ext/python/lib/python2.6/site-packages/sitecustomize.py")
@@ -290,7 +290,7 @@ def setPaths(clusterNode):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
 
-            ssh.connect(clusterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(clusterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
 
             (stdin, stdout, stderr) = ssh.exec_command(
                 "echo 'source /usr/local/greenplum-db/greenplum_path.sh\n' >> ~/.bashrc")
@@ -324,8 +324,8 @@ def makeDirectories(clusterNode):
 
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(clusterNode["externalIP"], 22, str(os.environ.get("SSH_USERNAME")), None, pkey=None,
-                        key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")),
+            ssh.connect(clusterNode["externalIP"], 22, str(os.environ["SSH_USERNAME"]), None, pkey=None,
+                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]),
                         timeout=120)
             if "master" in clusterNode["role"]:
                 (stdin, stdout, stderr) = ssh.exec_command("sudo mkdir -p /data/disk1/master")
@@ -333,8 +333,8 @@ def makeDirectories(clusterNode):
                 stderr.readlines()
             else:
 
-                numDisks = os.environ.get("DISK_QTY")
-                segDBs = os.environ.get("SEGMENTDBS")
+                numDisks = os.environ["DISK_QTY"]
+                segDBs = os.environ["SEGMENTDBS"]
                 for diskNum in range(1, int(numDisks) + 1):
                     (stdin, stdout, stderr) = ssh.exec_command("sudo mkdir -p /data/disk"+str(diskNum)+"/primary")
                     stdout.readlines()
@@ -365,9 +365,9 @@ def setGPADMINPW(masterNode):
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
             (stdin, stdout, stderr) = ssh.exec_command(
-                "psql -c \"alter user gpadmin with password '" + str(os.environ.get("GPADMIN_PW")) + "';\"")
+                "psql -c \"alter user gpadmin with password '" + str(os.environ["GPADMIN_PW"]) + "';\"")
 
             # (stdin, stdout, stderr) = ssh.exec_command("alter user gpadmin with password '"+str(os.environ.get("GPADMIN_PW"))+ "';")
             stdout.readlines()
@@ -394,7 +394,7 @@ def modifyPHGBA(masterNode):
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(masterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
             (stdin, stdout, stderr) = ssh.exec_command(
                 "echo 'host all gpadmin " + accessNode['internalIP'] + "/0 md5' >> /data/master/gpseg-1/pg_hba.conf")
             stdout.readlines()
@@ -424,8 +424,8 @@ def uncompressFiles(clusterNode, downloads):
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
 
-            ssh.connect(clusterNode["externalIP"], 22, str(os.environ.get("SSH_USERNAME")), None, pkey=None,
-                        key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")), timeout=120)
+            ssh.connect(clusterNode["externalIP"], 22, str(os.environ["SSH_USERNAME"]), None, pkey=None,
+                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
 
             for file in downloads:
                 if ".zip" in file["NAME"]:
@@ -457,8 +457,8 @@ def prepFiles(clusterNode):
 
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(clusterNode["externalIP"], 22, str(os.environ.get("SSH_USERNAME")), None, pkey=None,
-                        key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")), timeout=120)
+            ssh.connect(clusterNode["externalIP"], 22, str(os.environ["SSH_USERNAME"]), None, pkey=None,
+                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
 
             (stdin, stdout, stderr) = ssh.exec_command("sudo sed -i 's/more <</cat <</g' /tmp/greenplum-db*.bin")
             stdout.readlines()
@@ -496,8 +496,8 @@ def installBits(clusterNode):
 
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(clusterNode["externalIP"], 22, str(os.environ.get("SSH_USERNAME")), None, pkey=None,
-                        key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")),
+            ssh.connect(clusterNode["externalIP"], 22, str(os.environ["SSH_USERNAME"]), None, pkey=None,
+                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]),
                         timeout=120)
 
             (stdin, stdout, stderr) = ssh.exec_command("sudo /tmp/greenplum-db*.bin")
@@ -529,9 +529,9 @@ def initDB(clusterNode, clusterName):
 
     ## BUILD DATA DIRECTORY AND MIRROR DIRECTORY
     # SHOULD BE #SEGDB ENTRIES ACROSS # DRIVES.
-    numDisks = os.environ.get("DISK_QTY")
-    segDBs = os.environ.get("SEGMENTDBS")
-    diskBase = os.environ.get("BASE_HOME")
+    numDisks = os.environ["DISK_QTY"]
+    segDBs = os.environ["SEGMENTDBS"]
+    diskBase = os.environ["BASE_HOME"]
     dataDirectories = ""
     mirrorDirectories = ""
 
@@ -550,14 +550,14 @@ def initDB(clusterNode, clusterName):
                 str(diskNum)+"/mirror "
 
 
-    with open(str(os.environ.get("CAPE_HOME"))+"/templates/gpinitsystem_config.template", 'r+') as gpConfigTemplate:
+    with open(str(os.environ["CAPE_HOME"])+"/templates/gpinitsystem_config.template", 'r+') as gpConfigTemplate:
         gpConfigTemplateData = gpConfigTemplate.read()
         gpConfigTemplateModData = gpConfigTemplateData.replace("%MASTER%", clusterNode["nodeName"])
         gpConfigDirectoriesData = gpConfigTemplateModData.replace("declare -a DATA_DIRECTORY=(/data/primary /data/primary)","declare -a DATA_DIRECTORY=("+dataDirectories+")")
         gpConfigTemplateData  = gpConfigDirectoriesData.replace("declare -a MIRROR_DATA_DIRECTORY=(/data/mirror /data/mirror)","declare -a MIRROR_DATA_DIRECTORY=("+mirrorDirectories+")")
 
 
-    with open(os.environ.get("CAPE_HOME") + "/clusterConfigs/" + str(clusterName) + "/gpinitsystem_config",
+    with open(os.environ["CAPE_HOME"] + "/clusterConfigs/" + str(clusterName) + "/gpinitsystem_config",
               'w') as gpConfigCluster:
         gpConfigCluster.write(gpConfigTemplateData)
 
@@ -568,8 +568,8 @@ def initDB(clusterNode, clusterName):
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(clusterNode["externalIP"], 22, os.environ.get("SSH_USERNAME"), None, pkey=None,
-                        key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")),
+            ssh.connect(clusterNode["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
+                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]),
                         timeout=120)
             sftp = ssh.open_sftp()
             sftp.put("gpinitsystem_config", "/tmp/gpinitsystem_config.cape")
@@ -592,7 +592,7 @@ def initDB(clusterNode, clusterName):
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(clusterNode["externalIP"], 22, "gpadmin", str(os.environ.get("GPADMIN_PW")), timeout=120)
+            ssh.connect(clusterNode["externalIP"], 22, "gpadmin", str(os.environ["GPADMIN_PW"]), timeout=120)
             #
             # Adding gpssh-exkeys here for now
             # We need to figure out the key exchange and then remove this step

--- a/ClusterBuilder/InstallGPDB.py
+++ b/ClusterBuilder/InstallGPDB.py
@@ -144,8 +144,8 @@ def installComponents(masterNode, downloads):
 def verifyInstall(masterNode, clusterDictionary):
     numberSegments = int(clusterDictionary["segmentCount"])
 
-    #totalSegmentDBs = numberSegments * int(clusterDictionary["segmentDBs"])
-    totalSegmentDBs = numberSegments * int(os.environ.get("SEGMENTDBS"))
+    totalSegmentDBs = numberSegments * int(clusterDictionary["segmentDBs"])
+    #totalSegmentDBs = numberSegments * int(os.environ.get("SEGMENTDBS"))
 
 
 

--- a/ClusterBuilder/InstallGPDB.py
+++ b/ClusterBuilder/InstallGPDB.py
@@ -600,10 +600,10 @@ def initDB(clusterNode, clusterName):
             # Adding gpssh-exkeys here for now
             # We need to figure out the key exchange and then remove this step
             #
-            (stdin, stdout, stderr) = ssh.exec_command(
-                "source /usr/local/greenplum-db/greenplum_path.sh;gpssh-exkeys -f /tmp/workers")
-            stdout.readlines()
-            stderr.readlines()
+            # (stdin, stdout, stderr) = ssh.exec_command(
+            #     "source /usr/local/greenplum-db/greenplum_path.sh;gpssh-exkeys -f /tmp/workers")
+            # stdout.readlines()
+            # stderr.readlines()
             (stdin, stdout, stderr) = ssh.exec_command(
                 "source /usr/local/greenplum-db/greenplum_path.sh;gpinitsystem -c /tmp/gpinitsystem_config.cape -a")
             stdout.readlines()

--- a/ClusterBuilder/SoftwareDownload.py
+++ b/ClusterBuilder/SoftwareDownload.py
@@ -11,7 +11,7 @@ from paramiko import WarningPolicy
 def downloadSoftware(clusterDictionary):
     warnings.simplefilter("ignore")
     package = clusterDictionary["clusterType"]
-    headers = {"Authorization": "Token " + os.environ.get("PIVNET_APIKEY")}
+    headers = {"Authorization": "Token " + os.environ["PIVNET_APIKEY"]}
 
     # FIND PRODUCT
     response = requests.get("https://network.pivotal.io/api/v2/products")
@@ -70,7 +70,7 @@ def downloadSoftware(clusterDictionary):
                         downloads.append(downloadFile)
             elif "Analytics" in fileInfo["name"]:
                 for file in fileInfo["product_files"]:
-                    if os.environ.get("MADLIB_VERSION") in file["name"]:  # NEED TO FIX THIS TO BE AUTOMATIC
+                    if os.environ["MADLIB_VERSION"] in file["name"]:  # NEED TO FIX THIS TO BE AUTOMATIC
                         downloadFile["URL"] = file["_links"]["download"].get("href")
                         downloadFile["NAME"] = str(file["aws_object_key"]).split("/")[2]
                         downloadFile["TARGET"] = 2
@@ -142,14 +142,14 @@ def downloadSoftware(clusterDictionary):
 
                         ssh = paramiko.SSHClient()
                         ssh.set_missing_host_key_policy(WarningPolicy())
-                        ssh.connect(node["externalIP"], 22, os.environ.get("SSH_USERNAME"), None, pkey=None,
-                                    key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")),
+                        ssh.connect(node["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
+                                    key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]),
                                     timeout=120)
 
                         for file in downloads:
                             (stdin, stdout, stderr) = ssh.exec_command(
-                                "wget --header=\"Authorization: Token " + os.environ.get(
-                                    "PIVNET_APIKEY") + "\" --post-data='' " + str(
+                                "wget --header=\"Authorization: Token " + str(os.environ[
+                                    "PIVNET_APIKEY"]) + "\" --post-data='' " + str(
                                     file['URL']) + " -O /tmp/" + str(file['NAME']))
 
                             stderr.readlines()
@@ -182,29 +182,29 @@ def hostDownloads(node, downloads):
             attemptCount += 1
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(WarningPolicy())
-            ssh.connect(node["externalIP"], 22, os.environ.get("SSH_USERNAME"), None, pkey=None,
-                        key_filename=str(os.environ.get("CONFIGS_PATH")) + str(os.environ.get("SSH_KEY")), timeout=120)
+            ssh.connect(node["externalIP"], 22, os.environ["SSH_USERNAME"], None, pkey=None,
+                        key_filename=str(os.environ["CONFIGS_PATH"]) + str(os.environ["SSH_KEY"]), timeout=120)
             for file in downloads:
                 if (file["TARGET"] == 2) and ("master" in node["role"]):
-                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ.get(
-                        "PIVNET_APIKEY") + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
+                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ[
+                        "PIVNET_APIKEY"] + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
                     stderr.readlines()
                     stdout.readlines()
                 elif (file["TARGET"] == 1) and ("access" in node["role"]):
 
-                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ.get(
-                        "PIVNET_APIKEY") + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
+                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ[
+                        "PIVNET_APIKEY"] + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
                     stderr.readlines()
                     stdout.readlines()
                 elif (file["TARGET"] == 3) and ("worker" in node["role"]):
 
-                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ.get(
-                        "PIVNET_APIKEY") + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
+                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ[
+                        "PIVNET_APIKEY"] + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
                     stderr.readlines()
                     stdout.readlines()
                 elif (file["TARGET"] == 0):  # and ("access" not in node["role"]):  Decided to put GPDB on ACCESS
-                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ.get(
-                        "PIVNET_APIKEY") + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
+                    (stdin, stdout, stderr) = ssh.exec_command("wget --header=\"Authorization: Token " + os.environ[
+                        "PIVNET_APIKEY"] + "\" --post-data='' " + str(file['URL']) + " -O /tmp/" + str(file['NAME']))
                     stderr.readlines()
                     stdout.readlines()
 

--- a/ClusterDestroyer/ClusterDestroyer.py
+++ b/ClusterDestroyer/ClusterDestroyer.py
@@ -18,14 +18,14 @@ def destroyServers(clusterDictionary):
     try:
 
         ComputeEngine = get_driver(Provider.GCE)
-        driver = ComputeEngine(os.environ.get("SVC_ACCOUNT"),
-                               str(os.environ.get("CONFIGS_PATH")) +
-                               str(os.environ.get("SVC_ACCOUNT_KEY")),
-                               project=str(os.environ.get("PROJECT")),
-                               datacenter=str(os.environ.get("ZONE")))
+        driver = ComputeEngine(os.environ["SVC_ACCOUNT"],
+                               str(os.environ["CONFIGS_PATH"]) +
+                               str(os.environ["SVC_ACCOUNT_KEY"]),
+                               project=str(os.environ["PROJECT"]),
+                               datacenter=str(os.environ["ZONE"]))
         nodeList = []
 
-        nodes = driver.list_nodes(ex_zone=str(os.environ.get("ZONE")))
+        nodes = driver.list_nodes(ex_zone=str(os.environ["ZONE"]))
         for node in nodes:
             if clusterDictionary["clusterName"] in node.name:
                 nodeList.append(node)

--- a/QueryCluster/QueryCluster.py
+++ b/QueryCluster/QueryCluster.py
@@ -15,13 +15,13 @@ def checkServerState(clusterDictionary):
     print clusterDictionary["clusterName"] + ": Querying Cluster State Started"
     try:
         ComputeEngine = get_driver(Provider.GCE)
-        driver = ComputeEngine(os.environ.get("SVC_ACCOUNT"),
-                               str(os.environ.get("CONFIGS_PATH")) +
-                               str(os.environ.get("SVC_ACCOUNT_KEY")),
-                               project=str(os.environ.get("PROJECT")),
-                               datacenter=str(os.environ.get("ZONE")))
+        driver = ComputeEngine(os.environ["SVC_ACCOUNT"],
+                               str(os.environ["CONFIGS_PATH"]) +
+                               str(os.environ["SVC_ACCOUNT_KEY"]),
+                               project=str(os.environ["PROJECT"]),
+                               datacenter=str(os.environ["ZONE"]))
 
-        nodes = driver.list_nodes(ex_zone=str(os.environ.get("ZONE")))
+        nodes = driver.list_nodes(ex_zone=str(os.environ["ZONE"]))
         if not nodes:
             print "Did not find any nodes for that cluster!"
         else:

--- a/cape.py
+++ b/cape.py
@@ -109,8 +109,8 @@ def cliParse():
             logging.debug("Creating a Greenplum Database Cluster:" + clusterDictionary["clusterName"])
             logging.debug('With Dictionary: ' + json.dumps(clusterDictionary))
             ClusterBuilder.buildServers(clusterDictionary)
-            #downloads = SoftwareDownload.downloadSoftware(clusterDictionary)
-            #InstallGPDB.installGPDB(clusterDictionary, downloads)
+            downloads = SoftwareDownload.downloadSoftware(clusterDictionary)
+            InstallGPDB.installGPDB(clusterDictionary, downloads)
             stopTime = datetime.datetime.today()
             print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime
             logging.debug("Cluster " + sys.argv[1] + " Completion Time: " + str(stopTime))

--- a/cape.py
+++ b/cape.py
@@ -36,7 +36,7 @@ def cliParse():
 
     parser_create.add_argument("--config", dest='config', default=str(os.getcwd())+'/configs/config.env', action="store", help="Config.env file",
                                required=False)
-    parser_create.add_argument("--log", dest='logfile', default=str(os.getcwd())+'cape.log', action="store", help="Location of cape log file",
+    parser_create.add_argument("--log", dest='logfile', default=str(os.getcwd())+'/cape.log', action="store", help="Location of cape log file",
                                required=False)
     parser_create.add_argument("--loglevel", dest='loglevel', default='DEBUG', action="store", help="Logging level of cape log file",
                                required=False)
@@ -54,7 +54,7 @@ def cliParse():
     # Adding in type as an optinoal arg for now. to be used in the future
     parser_query.add_argument("--type", dest='type', action="store",
                                help="Type of cluster to be create (gpdb/hdb/vanilla", required=False)
-    parser_query.add_argument("--log", dest='logfile', default=str(os.getcwd())+'cape.log', action="store", help="Location of cape log file",
+    parser_query.add_argument("--log", dest='logfile', default=str(os.getcwd())+'/cape.log', action="store", help="Location of cape log file",
                                required=False)
     parser_query.add_argument("--loglevel", dest='loglevel', default='DEBUG', action="store", help="Logging level of cape log file",
                                required=False)
@@ -72,7 +72,7 @@ def cliParse():
     # Adding in type as an optinoal arg for now. to be used in the future
     parser_destroy.add_argument("--type", dest='type', action="store",
                                help="Type of cluster to be create (gpdb/hdb/vanilla", required=False)
-    parser_destroy.add_argument("--log", dest='logfile', default=str(os.getcwd())+'cape.log', action="store", help="Location of cape log file",
+    parser_destroy.add_argument("--log", dest='logfile', default=str(os.getcwd())+'/cape.log', action="store", help="Location of cape log file",
                                required=False)
     parser_destroy.add_argument("--loglevel", dest='loglevel', default='DEBUG', action="store", help="Logging level of cape log file",
                                required=False)

--- a/cape.py
+++ b/cape.py
@@ -92,7 +92,7 @@ def cliParse():
             print clusterDictionary["clusterName"] + ": Creating a Greenplum Database Cluster"
             logging.debug("Creating a Greenplum Database Cluster:" + clusterDictionary["clusterName"])
             logging.debug('With Dictionary: ' + json.dumps(clusterDictionary))
-            #ClusterBuilder.buildServers(clusterDictionary)
+            ClusterBuilder.buildServers(clusterDictionary)
             #downloads = SoftwareDownload.downloadSoftware(clusterDictionary)
             #InstallGPDB.installGPDB(clusterDictionary, downloads)
         elif (args.type == "hdb"):

--- a/cape.py
+++ b/cape.py
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     #ch.setFormatter(formatter)
     #root.addHandler(ch)
     print  "Start Time: ", startTime
-    logging.info('Cape Started with Args:' + sys.argv[:])
+    logging.info('Cape Started with Args:' + str(sys.argv[1:]))
     os.environ["CAPE_HOME"] = os.getcwd()
     logging.debug('CAPE_HOME=' + os.environ["CAPE_HOME"])
     cliParse()

--- a/cape.py
+++ b/cape.py
@@ -36,7 +36,10 @@ def cliParse():
 
     parser_create.add_argument("--config", dest='config', default=str(os.getcwd())+'/configs/config.env', action="store", help="Config.env file",
                                required=False)
-
+    parser_create.add_argument("--log", dest='logfile', default=str(os.getcwd())+'cape.log', action="store", help="Location of cape log file",
+                               required=False)
+    parser_create.add_argument("--loglevel", dest='loglevel', default='DEBUG', action="store", help="Logging level of cape log file",
+                               required=False)
     #parser_create.add_argument("-l", dest='lab', action='store_true', required=False,
     #                         help="Include Lab creation in Cluster Buildout")
 
@@ -51,6 +54,10 @@ def cliParse():
     # Adding in type as an optinoal arg for now. to be used in the future
     parser_query.add_argument("--type", dest='type', action="store",
                                help="Type of cluster to be create (gpdb/hdb/vanilla", required=False)
+    parser_query.add_argument("--log", dest='logfile', default=str(os.getcwd())+'cape.log', action="store", help="Location of cape log file",
+                               required=False)
+    parser_query.add_argument("--loglevel", dest='loglevel', default='DEBUG', action="store", help="Logging level of cape log file",
+                               required=False)
     parser_gpdb.add_argument("--clustername", dest='clustername', action="store", help="Name of Cluster to be Staged",
                              required=True)
 
@@ -65,10 +72,19 @@ def cliParse():
     # Adding in type as an optinoal arg for now. to be used in the future
     parser_destroy.add_argument("--type", dest='type', action="store",
                                help="Type of cluster to be create (gpdb/hdb/vanilla", required=False)
-    logging.debug('Parsing Args')
+    parser_destroy.add_argument("--log", dest='logfile', default=str(os.getcwd())+'cape.log', action="store", help="Location of cape log file",
+                               required=False)
+    parser_destroy.add_argument("--loglevel", dest='loglevel', default='DEBUG', action="store", help="Logging level of cape log file",
+                               required=False)
     args = parser.parse_args()
 
     clusterDictionary = {}
+
+    startTime = datetime.datetime.today()
+    logging.basicConfig(filename=args.logfile,level=args.loglevel, format='[%(asctime)s] %(pathname)s {%(module)s:%(funcName)s:%(lineno)d} %(levelname)s %(threadName)s - %(message)s')
+    print  "Start Time: ", startTime
+    logging.info('Cape Started with Args:' + str(sys.argv[1:]))
+    logging.debug('CAPE_HOME=' + os.environ["CAPE_HOME"])
 
     if (args.subparser_name == "create"):
 
@@ -95,6 +111,11 @@ def cliParse():
             ClusterBuilder.buildServers(clusterDictionary)
             #downloads = SoftwareDownload.downloadSoftware(clusterDictionary)
             #InstallGPDB.installGPDB(clusterDictionary, downloads)
+            stopTime = datetime.datetime.today()
+            print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime
+            logging.debug("Cluster " + sys.argv[1] + " Completion Time: " + str(stopTime))
+            print  "Elapsed Time: ", stopTime - startTime
+            logging.info('Elapsed Time: ' + str(stopTime - startTime))
         elif (args.type == "hdb"):
             print "HDB Builder"
             ClusterBuilder.buildServers(clusterDictionary)
@@ -131,6 +152,11 @@ def cliParse():
             #     with open("./" + clusterName + "/clusterInfo.json") as clusterInfoFile:
             #         clusterInfo = json.load(clusterInfoFile)
             #     Users.gpControl(clusterInfo,args.action)
+            stopTime = datetime.datetime.today()
+            print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime
+            logging.debug("Cluster " + sys.argv[1] + " Completion Time: " + str(stopTime))
+            print  "Elapsed Time: ", stopTime - startTime
+            logging.info('Elapsed Time: ' + str(stopTime - startTime))
     elif (args.subparser_name == "query"):
         clusterDictionary["clusterName"] = args.clustername
         clusterDictionary["nodeQty"] = args.nodes
@@ -140,6 +166,11 @@ def cliParse():
             os.environ["CONFIGS_PATH"] = os.path.dirname(args.config) + '/'
         print clusterDictionary["clusterName"] + ": Querying Nodes in a Cluster"
         QueryCluster.checkServerState(clusterDictionary)
+        stopTime = datetime.datetime.today()
+        print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime
+        logging.debug("Cluster " + sys.argv[1] + " Completion Time: " + str(stopTime))
+        print  "Elapsed Time: ", stopTime - startTime
+        logging.info('Elapsed Time: ' + str(stopTime - startTime))
     elif (args.subparser_name == "destroy"):
         clusterDictionary["clusterName"] = args.clustername
         clusterDictionary["nodeQty"] = args.nodes
@@ -149,23 +180,14 @@ def cliParse():
             os.environ["CONFIGS_PATH"] = os.path.dirname(args.config) + '/'
         print clusterDictionary["clusterName"] + ": Destroying Cluster"
         ClusterDestroyer.destroyServers(clusterDictionary)
+        stopTime = datetime.datetime.today()
+        print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime
+        logging.debug("Cluster " + sys.argv[1] + " Completion Time: " + str(stopTime))
+        print  "Elapsed Time: ", stopTime - startTime
+        logging.info('Elapsed Time: ' + str(stopTime - startTime))
 
 
 if __name__ == '__main__':
-    startTime = datetime.datetime.today()
-    logging.basicConfig(filename='cape.log',level=logging.DEBUG, format='[%(asctime)s] %(module)s {%(pathname)s:%(funcName)s:%(lineno)d} %(levelname)s - %(message)s')
-    #ch = logging.StreamHandler(sys.stdout)
-    #ch.setLevel(logging.DEBUG)
-    #formatter = logging.Formatter('[%(asctime)s] %(module)s {%(pathname)s:%(funcName)s:%(lineno)d} %(levelname)s - %(message)s','%m-%d %H:%M:%S')
-    #ch.setFormatter(formatter)
-    #root.addHandler(ch)
-    print  "Start Time: ", startTime
-    logging.info('Cape Started with Args:' + str(sys.argv[1:]))
+
     os.environ["CAPE_HOME"] = os.getcwd()
-    logging.debug('CAPE_HOME=' + os.environ["CAPE_HOME"])
     cliParse()
-    stopTime = datetime.datetime.today()
-    print  "Cluster " + sys.argv[1] + " Completion Time: ", stopTime
-    logging.debug("Cluster " + sys.argv[1] + " Completion Time: " + str(stopTime))
-    print  "Elapsed Time: ", stopTime - startTime
-    logging.info('Elapsed Time: ' + str(stopTime - startTime))

--- a/cape.py
+++ b/cape.py
@@ -77,6 +77,8 @@ def cliParse():
             load_dotenv(args.config)
             os.environ["CONFIGS_PATH"] = os.path.dirname(args.config) + '/'
             logging.debug('CONFIGS_PATH=' + os.environ["CONFIGS_PATH"])
+            for key in os.environ.keys():
+                logging.debug(key + '=' + str(os.environ[key]))
         clusterDictionary["clusterName"] = args.clustername
         clusterDictionary["nodeQty"] = args.nodes
         clusterDictionary["clusterType"] = "pivotal-" + args.type

--- a/cape.py
+++ b/cape.py
@@ -80,7 +80,7 @@ def cliParse():
         clusterDictionary["clusterName"] = args.clustername
         clusterDictionary["nodeQty"] = args.nodes
         clusterDictionary["clusterType"] = "pivotal-" + args.type
-        clusterDictionary["segmentDBs"] = os.environ.get["SEGMENTDBS"]
+        clusterDictionary["segmentDBs"] = os.environ["SEGMENTDBS"]
         clusterDictionary["masterCount"] = 0
         clusterDictionary["accessCount"] = 0
         clusterDictionary["segmentCount"] = 0


### PR DESCRIPTION
Users will have a cape.log in the same working directory they run cape from. The default log level is DEBUG.

Fixes: ssh-hanging when exchanging keys
Removed: gpssh-exkeys
Added: FQDNs along with internal IP and short names to known_hosts as well